### PR TITLE
Adding RH cert-manager artifacts

### DIFF
--- a/argocd/overlays/osc-cl3/applications/envs/osc/osc-cl1/os-climate/kustomization.yaml
+++ b/argocd/overlays/osc-cl3/applications/envs/osc/osc-cl1/os-climate/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - acme-operator.yaml
-  - cert-manager.yaml
+#  - cert-manager.yaml
   - cloudbeaver.yaml
   - cluster-resources.yaml
   - das.yaml

--- a/cluster-scope/base/core/namespaces/openshift-cert-manager-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-cert-manager-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-cert-manager-operator
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-cert-manager-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-cert-manager-operator/namespace.yaml
@@ -1,0 +1,6 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cert-manager-operator
+spec: {}

--- a/cluster-scope/base/operator.openshift.io/certmanager/cluster/certmanager.yaml
+++ b/cluster-scope/base/operator.openshift.io/certmanager/cluster/certmanager.yaml
@@ -1,0 +1,15 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+spec:
+  logLevel: Normal
+  managementState: Managed
+  observedConfig: null
+  operatorLogLevel: Normal
+  unsupportedConfigOverrides:
+    controller:
+      args:
+        - '--dns01-recursive-nameservers=1.1.1.1:53'
+        - '--dns01-recursive-nameservers-only'
+        - '--cluster-resource-namespace=openshift-cert-manager'

--- a/cluster-scope/base/operator.openshift.io/certmanager/cluster/kustomization.yaml
+++ b/cluster-scope/base/operator.openshift.io/certmanager/cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- certmanager.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-cert-manager-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-cert-manager-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-operators
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-cert-manager-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-cert-manager-operator/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: openshift-cert-manager-operator
+spec:
+  channel: tech-preview
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: openshift-cert-manager.v1.7.1

--- a/cluster-scope/bundles/openshift-cert-manager/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-cert-manager/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/openshift-cert-manager-operator
+  - ../../base/operators.coreos.com/subscriptions/openshift-cert-manager-operator

--- a/cluster-scope/overlays/osc/osc-cl1/cert-manager/api/certificate.yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/cert-manager/api/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-certs
+spec:
+  dnsNames:
+    - "api.odh-cl1.apps.os-climate.org"
+    - "*.apps.odh-cl1.apps.os-climate.org"
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  secretName: api-certs
+  duration: 2160h0m0s
+  renewBefore: 360h0m0s

--- a/cluster-scope/overlays/osc/osc-cl1/cert-manager/api/kustomization .yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/cert-manager/api/kustomization .yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-config
+resources:
+  - certificate.yaml

--- a/cluster-scope/overlays/osc/osc-cl1/cert-manager/clusterissuer.yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/cert-manager/clusterissuer.yaml
@@ -1,0 +1,22 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-production
+spec:
+  acme:
+    email: mmikhail@redhat.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    solvers:
+      - dns01:
+          route53:
+            accessKeyID: AKIAZNQ2HXS5NOCJNRWM
+            hostedZoneID: Z04490453K6YE8HM7YHJ6
+            region: us-east-1
+            secretAccessKeySecretRef:
+              key: secret-access-key
+              name: route53-aws-key
+        selector:
+          dnsZones:
+            - apps.os-climate.org

--- a/cluster-scope/overlays/osc/osc-cl1/cert-manager/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/cert-manager/externalsecrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - route53-aws-key.yaml

--- a/cluster-scope/overlays/osc/osc-cl1/cert-manager/externalsecrets/route53-aws-key.yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/cert-manager/externalsecrets/route53-aws-key.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: route53-aws-key
+spec:
+    secretStoreRef:
+        name: osc-vault-store
+        kind: SecretStore
+    target:
+        name: route53-aws-key
+    dataFrom:
+        - extract:
+              key: osc/osc-cl1/openshift-cert-manager/route53-aws-key

--- a/cluster-scope/overlays/osc/osc-cl1/cert-manager/ingress/certificate.yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/cert-manager/ingress/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: router-certs
+spec:
+  dnsNames:
+    - "api.odh-cl1.apps.os-climate.org"
+    - "*.apps.odh-cl1.apps.os-climate.org"
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  secretName: router-certs
+  duration: 2160h0m0s
+  renewBefore: 360h0m0s

--- a/cluster-scope/overlays/osc/osc-cl1/cert-manager/ingress/kustomization.yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/cert-manager/ingress/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-ingress
+resources:
+  - certificate.yaml

--- a/cluster-scope/overlays/osc/osc-cl1/cert-manager/kustomization.yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/cert-manager/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterissuer.yaml
+  - externalsecrets
+  - ingress

--- a/cluster-scope/overlays/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/kustomization.yaml
@@ -46,7 +46,8 @@ resources:
 - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-readers
 - ../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
 - ../../../bundles/external-secrets-operator
-- ../../../bundles/cert-manager
+#- ../../../bundles/cert-manager
+- ../../../bundles/openshift-cert-manager-operator
 - ../../../bundles/grafana-operator
 - ../../../bundles/kepler
 - ../../../bundles/opf-monitoring
@@ -54,6 +55,7 @@ resources:
 - ../../../bundles/openshift-pipelines
 - ../../../bundles/reloader
 - ../../../bundles/training-operator
+- ../../../base/operator.openshift.io/certmanager/cluster
 - ../common
 - apiserver
 - configmaps/service-catalog-k8s-plugin.yaml
@@ -64,3 +66,4 @@ resources:
 - machineconfigs/kepler
 - nvidia-gpu
 - secret-mgmt
+- cert-manager

--- a/cluster-scope/overlays/osc/osc-cl2/machinesets/machineset-notebook-gpu-p.yaml
+++ b/cluster-scope/overlays/osc/osc-cl2/machinesets/machineset-notebook-gpu-p.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     machine.openshift.io/cluster-api-cluster: odh-cl2-jlxqf
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: odh-cl2-jlxqf


### PR DESCRIPTION
Part of https://github.com/os-climate/os_c_data_commons/issues/114
- removing old deployment of the cert-manager including argocd app
- add Openshift cert manager operator and artifacts 
- reduce number of GPU nodes on cluster 2 (based on low usage ) 