### PR TITLE
Fixes for cert-manager to odh-cl2

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-cert-manager-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-cert-manager-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-cert-manager-operator
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-cert-manager-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-cert-manager-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-cert-manager-operator-
+  namespace: openshift-cert-manager-operator
+spec: {}

--- a/cluster-scope/bundles/openshift-cert-manager-operator/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-cert-manager-operator/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - ../../base/core/namespaces/openshift-cert-manager-operator
   - ../../base/core/namespaces/openshift-cert-manager
+  - ../../base/operators.coreos.com/operatorgroups/openshift-cert-manager-operator
   - ../../base/operators.coreos.com/subscriptions/openshift-cert-manager-operator

--- a/cluster-scope/overlays/osc/osc-cl2/cert-manager/clusterissuer.yaml
+++ b/cluster-scope/overlays/osc/osc-cl2/cert-manager/clusterissuer.yaml
@@ -11,9 +11,7 @@ spec:
     solvers:
       - dns01:
           route53:
-            accessKeyIDSecretRef:
-              key: access-key-id
-              name: route53-aws-key
+            accessKeyID: AKIAZNQ2HXS5LH5RULMV
             hostedZoneID: Z04490453K6YE8HM7YHJ6
             region: us-east-1
             secretAccessKeySecretRef:


### PR DESCRIPTION
Fixes to add operatorgroup , removed unsupported yet access key reference to secret from clusterissuer. Part of https://github.com/os-climate/os_c_data_commons/issues/114