### PR TITLE
Update cl1 trino to v398

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/trino/externalsecrets/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino/externalsecrets/kustomization.yaml
@@ -2,4 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - s3buckets.yaml
+- shared-secret.yaml
 - trino-oauth.yaml
+- trino-secret-env.yaml
+- trino-secret-files.yaml

--- a/kfdefs/overlays/osc/osc-cl1/trino/externalsecrets/shared-secret.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino/externalsecrets/shared-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: shared-secret
+spec:
+  secretStoreRef:
+    name: osc-vault-store
+    kind: SecretStore
+  target:
+    name: shared-secret
+  dataFrom:
+    - extract:
+        key: osc/osc-cl1/odh-trino/shared-secret

--- a/kfdefs/overlays/osc/osc-cl1/trino/externalsecrets/trino-secret-env.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino/externalsecrets/trino-secret-env.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: trino-secret-env
+spec:
+  secretStoreRef:
+    name: osc-vault-store
+    kind: SecretStore
+  target:
+    name: trino-secret-env
+  dataFrom:
+    - extract:
+        key: osc/osc-cl1/odh-trino/trino-secret-env

--- a/kfdefs/overlays/osc/osc-cl1/trino/externalsecrets/trino-secret-files.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino/externalsecrets/trino-secret-files.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: trino-secret-files
+spec:
+  secretStoreRef:
+    name: osc-vault-store
+    kind: SecretStore
+  target:
+    name: trino-secret-files
+  dataFrom:
+    - extract:
+        key: osc/osc-cl1/odh-trino/trino-secret-files

--- a/kfdefs/overlays/osc/osc-cl1/trino/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino/kfdef.yaml
@@ -33,5 +33,5 @@ spec:
       name: trino
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.2
-  version: v1.1.0
+      uri: https://github.com/os-climate/odh-manifests/tarball/osc-cl1-v1.1.2
+  version: v1.1.3


### PR DESCRIPTION
This is done via an update to the manifest used for Trino. The latest version is 1.1.3.