### PR TITLE
Add keycloak-main app to ArgoCD

### DIFF
--- a/argocd/overlays/osc-cl3/applications/envs/osc/osc-cl3/osc-infra/keycloak.yaml
+++ b/argocd/overlays/osc-cl3/applications/envs/osc/osc-cl3/osc-infra/keycloak.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keycloak-main
+spec:
+  destination:
+    name: osc-cl3
+    namespace: keycloak-main
+  project: os-climate
+  source:
+    path: keycloak/overlays/osc/osc-cl3
+    repoURL: https://github.com/os-climate/ops-argocd.git
+    targetRevision: keycloak-init

--- a/argocd/overlays/osc-cl3/applications/envs/osc/osc-cl3/osc-infra/kustomization.yaml
+++ b/argocd/overlays/osc-cl3/applications/envs/osc/osc-cl3/osc-infra/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - ci-prow-test-pods.yaml
   - ci-prow.yaml
+  - keycloak.yaml
   # - peribolos-as-a-service.yaml
   - vault.yaml


### PR DESCRIPTION
This is currently pointing to a feature branch. Once it is ready to deploy, we will change this to main.