### PR TITLE
Update Trino to v424

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/trino/configs/catalogs/osc_datacommons_dev.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino/configs/catalogs/osc_datacommons_dev.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hive-metastore-osc-datacommons-dev:9083
 hive.s3.endpoint=${ENV:OSC_DATACOMMONS_DEV_S3_ENDPOINT_URL_PREFIX}${ENV:OSC_DATACOMMONS_DEV_S3_ENDPOINT}
 hive.s3.signer-type=S3SignerType

--- a/kfdefs/overlays/osc/osc-cl1/trino/configs/catalogs/osc_datacommons_prod.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino/configs/catalogs/osc_datacommons_prod.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hive-metastore-osc-datacommons-prod:9083
 hive.s3.endpoint=${ENV:OSC_DATACOMMONS_PROD_S3_ENDPOINT_URL_PREFIX}${ENV:OSC_DATACOMMONS_PROD_S3_ENDPOINT}
 hive.s3.signer-type=S3SignerType

--- a/kfdefs/overlays/osc/osc-cl1/trino/configs/jvm-coordinator.config
+++ b/kfdefs/overlays/osc/osc-cl1/trino/configs/jvm-coordinator.config
@@ -12,3 +12,4 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+-Dfile.encoding=UTF-8

--- a/kfdefs/overlays/osc/osc-cl1/trino/configs/jvm-worker.config
+++ b/kfdefs/overlays/osc/osc-cl1/trino/configs/jvm-worker.config
@@ -12,3 +12,4 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+-Dfile.encoding=UTF-8

--- a/kfdefs/overlays/osc/osc-cl1/trino/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino/kfdef.yaml
@@ -34,4 +34,4 @@ spec:
   repos:
     - name: manifests
       uri: https://github.com/os-climate/odh-manifests/tarball/osc-cl1-v1.1.2
-  version: v1.1.3
+  version: v1.1.4

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_hive_ingest.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_hive_ingest.properties
@@ -1,4 +1,4 @@
-connector.name=hive-hadoop2
+connector.name=hive
 hive.metastore.uri=thrift://hive-metastore-osc-datacommons-hive-ingest:9083
 hive.s3.endpoint=${ENV:OSC_DATACOMMONS_HIVE_INGEST_S3_ENDPOINT_URL_PREFIX}${ENV:OSC_DATACOMMONS_HIVE_INGEST_S3_ENDPOINT}
 hive.s3.signer-type=S3SignerType

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-coordinator.config
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-coordinator.config
@@ -12,4 +12,5 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+-Dfile.encoding=UTF-8
 -javaagent:/usr/lib/trino/lib/jmx_exporter.jar=8082:/etc/trino/prometheus/monitoring-config.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-worker.config
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-worker.config
@@ -12,4 +12,5 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+-Dfile.encoding=UTF-8
 -javaagent:/usr/lib/trino/lib/jmx_exporter.jar=8082:/etc/trino/prometheus/monitoring-config.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/kfdef.yaml
@@ -34,4 +34,4 @@ spec:
   repos:
     - name: manifests
       uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.2
-  version: v1.1.0
+  version: v1.1.4


### PR DESCRIPTION
Per release notes, the following changes have been made:
* Change deprecated/removed connector name `hive-hadoop2` to hive (Trino v408)
* Set JVM charset to UTF-8 explicitly (Trivo v424)