### PR TITLE
Removed GPU enabled node from odh-cl1 cluster

### DIFF
--- a/cluster-scope/overlays/osc/osc-cl1/machinesets/kustomization.yaml
+++ b/cluster-scope/overlays/osc/osc-cl1/machinesets/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - machineset-compute-notebook.yaml
-  - machineset-notebook-gpu-g.yaml
   - machineset-worker.yaml


### PR DESCRIPTION
GPU is rarely used in cl1 , to reduce expenses it has to be provision ad-hoc when it is needed for test purposes