### PR TITLE
Add minimal README marking repository as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# ops-argocd
-
-Repository for the configuration of ArgoCD on the management cluster.
-
 [![FINOS - Archived](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-archived.svg)](https://community.finos.org/docs/governance/lifecycle-stages/archived)
 
 > [!WARNING]
 > **This repository is archived and in a read-only state.**
 > You are welcome to download, clone, or fork this code, but please be aware that it is no longer actively maintained and may contain bugs or security vulnerabilities.
 >
-> **Interested in reviving this project?** If you would like to restore development activities, please contact the team at help@finos.org.
+> **Interested in reviving this project?** If you would like to restore development activities, please contact the team at info@os-climate.org.
+
+# ops-argocd
+
+Repository for the configuration of ArgoCD on the management cluster.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# ops-argocd
+
+Repository for the configuration of ArgoCD on the management cluster.
+
+[![FINOS - Archived](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-archived.svg)](https://community.finos.org/docs/governance/lifecycle-stages/archived)
+
+> [!WARNING]
+> **This repository is archived and in a read-only state.**
+> You are welcome to download, clone, or fork this code, but please be aware that it is no longer actively maintained and may contain bugs or security vulnerabilities.
+>
+> **Interested in reviving this project?** If you would like to restore development activities, please contact the team at help@finos.org.


### PR DESCRIPTION
## Summary
- Adds a minimal `README.md` to this repository, which previously had no root README.
- The README contains only the FINOS archived badge and the standard archived/read-only warning notice.

This unblocks the automated archival follow-up process, which requires a root README to mark the repo as archived.

Signed-off-by: Juan Estrella <juan.estrella@finos.org>

Made with [Cursor](https://cursor.com)